### PR TITLE
chore: set rumpo3 vehicle as default

### DIFF
--- a/server-data/resources/[bpt_addons]/bpt_importjob/config.lua
+++ b/server-data/resources/[bpt_addons]/bpt_importjob/config.lua
@@ -6,7 +6,7 @@ Config.Locale = "it"
 Config.OxInventory = ESX.GetConfig().OxInventory
 
 Config.AuthorizedVehicles = {
-	{ model = "rumpo", label = "Rumpo" },
+	{ model = "rumpo3", label = "Rumpo" },
 }
 
 Config.Zones = {


### PR DESCRIPTION
<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**

- Setting the "rumpo3" vehicle as default should resolve the stuck vehicle problem, it would appear that only rumpo vehicles with advertising lettering have this problem.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):