### PR TITLE
Fix SQL query in autovelox vehicle block check

### DIFF
--- a/server-data/resources/[bpt_addons]/bpt_autovelox/fxmanifest.lua
+++ b/server-data/resources/[bpt_addons]/bpt_autovelox/fxmanifest.lua
@@ -12,17 +12,15 @@ shared_script({
 
 server_scripts({
     "@es_extended/locale.lua",
-    "oxmysql/lib/MySQL.lua",
     "server/main.lua",
 })
 
 client_scripts({
     "@es_extended/locale.lua",
-    "oxmysql/lib/MySQL.lua",
     "client/main.lua",
 })
 
 dependency({
-    "oxmysql", 
-    "es_extended"
+    "oxmysql",
+    "es_extended",
 })

--- a/server-data/resources/[bpt_addons]/bpt_autovelox/server/main.lua
+++ b/server-data/resources/[bpt_addons]/bpt_autovelox/server/main.lua
@@ -1,7 +1,5 @@
 ESX = exports["es_extended"]:getSharedObject()
 
-local MySQL = exports["mysql-async"]:getMySQL()
-
 local autoveloxPositions = {
     { x = 249.217590, y = -1032.896729, z = 29.296753, speedLimit = 50 },
     { x = 1134.32, y = -982.34, z = 46.42, speedLimit = 70 },
@@ -125,8 +123,13 @@ AddEventHandler("autovelox:payFineAfter", function()
     end
 end)
 
-ESX.RegisterServerCallback("autovelox:isVehicleBlocked", function(source, cb, plate)
-    isVehicleBlocked(plate, function(isBlocked)
-        cb(isBlocked)
+ESX.RegisterServerCallback("autovelox:isVehicleBlocked", function(_, cb, plate)
+    exports.oxmysql:fetch('SELECT blocked_for_fine FROM owned_vehicles WHERE plate = ?', {plate}, function(result)
+        if result[1] and result[1].blocked_for_fine == 1 then
+            cb(true)
+        else
+            cb(false)
+        end
     end)
 end)
+


### PR DESCRIPTION
Replaced incorrect MySQL:update method with exports.oxmysql:fetch in the autovelox:isVehicleBlocked server callback. The original implementation incorrectly used an update method for a SELECT query, causing runtime errors and blocking proper vehicle plate verification. Now the callback retrieves blocked_for_fine correctly and returns the appropriate response to the client.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):