### PR TITLE
Add Full Refinery System with Persistent Item Processing and Delayed Rewards

### DIFF
--- a/server-data/resources/[bpt_addons]/bpt_refinery/client/client.lua
+++ b/server-data/resources/[bpt_addons]/bpt_refinery/client/client.lua
@@ -1,0 +1,45 @@
+local pedCoords = vec3(1076.650513, -1984.813232, 31.032227) -- Cambia con le tue coordinate
+local pedHeading = 180.0
+
+CreateThread(function()
+    RequestModel("s_m_m_snowcop_01")
+    while not HasModelLoaded("s_m_m_snowcop_01") do
+        Wait(0)
+    end
+
+    local ped = CreatePed(0, "s_m_m_snowcop_01", pedCoords.x, pedCoords.y, pedCoords.z - 1.0, pedHeading, false, true)
+    FreezeEntityPosition(ped, true)
+    SetEntityInvincible(ped, true)
+    SetBlockingOfNonTemporaryEvents(ped, true)
+
+    exports.ox_target:addLocalEntity(ped, {
+        {
+            name = "startFonderia",
+            icon = "fas fa-fire",
+            label = "Avvia lavorazione pietra",
+            onSelect = function()
+                TriggerServerEvent("fonderia:startLavorazione")
+            end,
+        },
+        {
+            name = "ritiraFonderia",
+            icon = "fas fa-box",
+            label = "Ritira materiali lavorati",
+            onSelect = function()
+                TriggerServerEvent("fonderia:ritiraMateriali")
+            end,
+        },
+    })
+end)
+
+CreateThread(function()
+    local blip = AddBlipForCoord(1076.650513, -1984.813232, 31.032227)
+    SetBlipSprite(blip, 365)
+    SetBlipDisplay(blip, 4)
+    SetBlipScale(blip, 0.8)
+    SetBlipColour(blip, 5)
+    SetBlipAsShortRange(blip, true)
+    BeginTextCommandSetBlipName("STRING")
+    AddTextComponentString("Fonderia")
+    EndTextCommandSetBlipName(blip)
+end)

--- a/server-data/resources/[bpt_addons]/bpt_refinery/fxmanifest.lua
+++ b/server-data/resources/[bpt_addons]/bpt_refinery/fxmanifest.lua
@@ -1,0 +1,22 @@
+fx_version("cerulean")
+game("gta5")
+
+author("bitpredator")
+description("Sistema di Fonderia - EmpireTown")
+version("2.0.0")
+
+shared_script({
+    "@es_extended/imports.lua",
+    "@ox_lib/init.lua",
+})
+
+server_scripts({
+    "@mysql-async/lib/MySQL.lua",
+    "server/*.lua",
+})
+
+client_scripts({
+    "client./*lua",
+})
+
+lua54("yes")

--- a/server-data/resources/[bpt_addons]/bpt_refinery/refinery.sql
+++ b/server-data/resources/[bpt_addons]/bpt_refinery/refinery.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS refinery_jobs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    identifier VARCHAR(60),
+    item VARCHAR(50),
+    amount INT,
+    ready_time DATETIME
+);

--- a/server-data/resources/[bpt_addons]/bpt_refinery/server/server.lua
+++ b/server-data/resources/[bpt_addons]/bpt_refinery/server/server.lua
@@ -1,0 +1,92 @@
+local materialiRari = {
+    {item = "emerald", percent = 2},
+    {item = "diamond", percent = 3},
+    {item = "gold", percent = 5},
+    {item = "steel", percent = 10},
+    {item = "iron", percent = 15},
+    {item = "copper", percent = 20},
+    {item = "gunpowder", percent = 10}
+}
+
+RegisterServerEvent("fonderia:startLavorazione", function()
+    local src = source
+    local xPlayer = ESX.GetPlayerFromId(src)
+    if not xPlayer then return end
+
+    local identifier = xPlayer.identifier
+
+    -- Controllo se ha già una lavorazione attiva
+    local existing = MySQL.query.await("SELECT * FROM refinery_jobs WHERE identifier = ?", {identifier})
+    if #existing > 0 then
+        TriggerClientEvent("ox_lib:notify", src, {type = "error", description = "Hai già una lavorazione attiva!"})
+        return
+    end
+
+    -- Controlli item e soldi
+    if xPlayer.getInventoryItem("stone").count < 30 then
+        TriggerClientEvent("ox_lib:notify", src, {type = "error", description = "Ti servono almeno 30 pietre"})
+        return
+    end
+
+    if xPlayer.getAccount("bank").money < 100 then
+        TriggerClientEvent("ox_lib:notify", src, {type = "error", description = "Non hai abbastanza soldi in banca"})
+        return
+    end
+
+    -- Rimozione item e soldi
+    xPlayer.removeInventoryItem("stone", 30)
+    xPlayer.removeAccountMoney("bank", 100)
+
+    -- Selezione dei materiali (fino a 3)
+    local totalItems = math.random(1, 3)
+    local rewardItems = {}
+
+    for i = 1, totalItems do
+        for _, mat in ipairs(materialiRari) do
+            if math.random(100) <= mat.percent then
+                table.insert(rewardItems, mat.item)
+                break
+            end
+        end
+    end
+
+    -- Salvataggio nel database
+    local ready_time = os.date("%Y-%m-%d %H:%M:%S", os.time() + 86400) -- 24h
+
+    for _, item in ipairs(rewardItems) do
+        MySQL.insert.await("INSERT INTO refinery_jobs (identifier, item, amount, ready_time) VALUES (?, ?, ?, ?)", {
+            identifier, item, 1, ready_time
+        })
+    end
+
+    TriggerClientEvent("ox_lib:notify", src, {type = "success", description = "Hai avviato la lavorazione, torna tra 24 ore"})
+end)
+
+RegisterServerEvent("fonderia:ritiraMateriali", function()
+    local src = source
+    local xPlayer = ESX.GetPlayerFromId(src)
+    if not xPlayer then return end
+
+    local identifier = xPlayer.identifier
+    local now = os.date("%Y-%m-%d %H:%M:%S")
+
+    local jobs = MySQL.query.await("SELECT * FROM refinery_jobs WHERE identifier = ? AND ready_time <= ?", {
+        identifier, now
+    })
+
+    if #jobs == 0 then
+        TriggerClientEvent("ox_lib:notify", src, {type = "error", description = "Nessun materiale pronto da ritirare"})
+        return
+    end
+
+    for _, job in pairs(jobs) do
+        xPlayer.addInventoryItem(job.item, job.amount)
+    end
+
+    -- Pulizia database
+    MySQL.query.await("DELETE FROM refinery_jobs WHERE identifier = ? AND ready_time <= ?", {
+        identifier, now
+    })
+
+    TriggerClientEvent("ox_lib:notify", src, {type = "success", description = "Hai ritirato i materiali lavorati!"})
+end)


### PR DESCRIPTION
This update introduces a complete stone refinery system for ESX-based FiveM servers.

### Features:
- Players can process 30x stone and pay $100 to initiate material refining
- Materials are extracted based on rarity percentages (emerald, diamond, copper, iron, steel, gold, gunpowder)
- Processing takes 24 real hours before items can be claimed
- All jobs are stored in a MySQL table (`refinery_jobs`) to ensure persistence after server restarts
- Integration with `ox_target` for NPC interaction
- Map blip added to help players locate the refinery
- Full notification support via `ox_lib`

Perfect for RP mining workflows and economy-based item progression.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):