### PR TITLE
Fix XSS Vulnerability in NUI Vehicle Menu (FiveM)

### DIFF
--- a/server-data/resources/[esx_addons]/esx_garage/nui/js/app.js
+++ b/server-data/resources/[esx_addons]/esx_garage/nui/js/app.js
@@ -1,4 +1,14 @@
 $(window).ready(function() {
+
+	function escapeHtml(unsafe) {
+		return String(unsafe)
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#039;');
+	}
+
 	window.addEventListener('message', function(event) {
 		const data = event.data;
 
@@ -107,13 +117,15 @@ $(window).ready(function() {
         '%';
 
 			html += '<div class=\'vehicle-listing\'>';
-			html += '<div>Model: <strong>' + vehicleData[i].model + '</strong></div>';
-			html += '<div>Plate: <strong>' + vehicleData[i].plate + '</strong></div>';
+			const model = escapeHtml(vehicleData[i].model);
+			html += '<div>Model: <strong>' + model + '</strong></div>';
+			const plate = escapeHtml(vehicleData[i].plate);
+			html += '<div>Plate: <strong>' + plate + '</strong></div>';
 			html +=
         '<div>Condition: <strong>' + vehicleDamagePercent + '</strong></div>';
 			html +=
         '<button data-button=\'spawn\' class=\'vehicle-action unstyled-button\' data-vehprops=\'' +
-        JSON.stringify(vehicleData[i].props) +
+        escapeHtml(JSON.stringify(vehicleData[i].props)) +
         '\'>' +
         locale.action +
         (amount ? ' ($' + amount + ')' : '') +
@@ -142,13 +154,15 @@ $(window).ready(function() {
         '%';
 
 			html += '<div class=\'vehicle-listing\'>';
-			html += '<div>Model: <strong>' + vehicleData[i].model + '</strong></div>';
-			html += '<div>Plate: <strong>' + vehicleData[i].plate + '</strong></div>';
+			const model = escapeHtml(vehicleData[i].model);
+			html += '<div>Model: <strong>' + model + '</strong></div>';
+			const plate = escapeHtml(vehicleData[i].plate);
+			html += '<div>Plate: <strong>' + plate + '</strong></div>';
 			html +=
         '<div>Condition: <strong>' + vehicleDamagePercent + '</strong></div>';
 			html +=
         '<button data-button=\'impounded\' class=\'vehicle-action red unstyled-button\' data-vehprops=\'' +
-        JSON.stringify(vehicleData[i].props) +
+        escapeHtml(JSON.stringify(vehicleData[i].props)) +
         '\'>' +
         locale.impound_action +
         '</button>';


### PR DESCRIPTION
This pull request addresses a client-side Cross-Site Scripting (XSS) vulnerability present in the NUI vehicle menu system of the FiveM garage interface.

### Changes

- Added a `escapeHtml()` utility function to sanitize all user-displayed HTML content.
- Sanitized vehicle model, plate, and serialized props in `getVehicles()` and `getImpoundedVehicles()` before injecting into the DOM using `.html()`.
- Ensured all dynamic strings are safely encoded to prevent script injection or malformed HTML rendering.

### Why?

Even though FiveM NUI doesn't communicate with the external web, users can manipulate their game client and inject malicious data via the Lua layer or spoofed NUI messages. This change prevents the possibility of client-side code execution due to unsafe HTML rendering.

### Notes

- This patch is fully backward compatible.
- It follows the principle of zero-trust for any data rendered inside the NUI browser.

### Testing

Tested in-game with various vehicle names and plates containing potentially unsafe characters (e.g., `<`, `"`, `'`, etc.) to verify that no code execution or DOM breakage occurs.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):