### PR TITLE
♻️ Improved variable clarity when retrieving network vehicle entity

### DIFF
--- a/server-data/resources/[esx_addons]/esx_garage/client/main.lua
+++ b/server-data/resources/[esx_addons]/esx_garage/client/main.lua
@@ -10,7 +10,7 @@ AddEventHandler("esx_garage:closemenu", function()
     menuIsShowed = false
     vehiclesList, vehiclesImpoundedList = {}, {}
 
-    SetNuiFocus(false)
+    SetNuiFocus(false, false)
     SendNUIMessage({
         hideAll = true,
     })

--- a/server-data/resources/[esx_addons]/esx_garage/server/main.lua
+++ b/server-data/resources/[esx_addons]/esx_garage/server/main.lua
@@ -17,9 +17,9 @@ AddEventHandler("esx_garage:updateOwnedVehicle", function(stored, parking, Impou
         xPlayer.showNotification(TranslateCap("veh_stored"))
     else
         ESX.OneSync.SpawnVehicle(data.vehicleProps.model, spawn, data.spawnPoint.heading, data.vehicleProps, function(vehicle)
-            local vehicle = NetworkGetEntityFromNetworkId(vehicle)
+            local networkVehicle = NetworkGetEntityFromNetworkId(vehicle)
             Wait(300)
-            TaskWarpPedIntoVehicle(GetPlayerPed(source), vehicle, -1)
+            TaskWarpPedIntoVehicle(GetPlayerPed(source), networkVehicle, -1)
         end)
     end
 end)


### PR DESCRIPTION
Refactored the local variable name from vehicle to networkVehicle after using NetworkGetEntityFromNetworkId(vehicle) to enhance code readability and avoid overwriting the original network ID. This change improves clarity and prevents potential logic issues caused by reusing the same variable name for different purposes.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):