### PR TITLE
Playboy Mansion MLO - FiveM Map

### DIFF
--- a/server-data/resources/[maps]/playboy/fxmanifest.lua
+++ b/server-data/resources/[maps]/playboy/fxmanifest.lua
@@ -1,4 +1,23 @@
 fx_version("adamant")
 game("gta5")
+
 this_is_a_map("yes")
-version("1.0.8")
+
+version("2.0.0")
+description("Mappa MLO Playboy Mansion")
+author("BPTNetwork")
+
+files({
+    "stream/**/*.ytyp",
+    "stream/**/*.ydr",
+    "stream/**/*.ymap",
+    "stream/**/*.ybn",
+    "stream/**/*.ymf",
+    "*.xml",
+})
+
+data_file("DLC_ITYP_REQUEST")("stream/**/*.ytyp")
+data_file("DLC_ITYP_REQUEST")("stream/**/*.ymf")
+
+data_file("DLC_ITYP_REQUEST")("stream/**/*.ybn")
+data_file("DLC_ITYP_REQUEST")("stream/**/*.ymap")

--- a/server-data/resources/[maps]/playboy/license
+++ b/server-data/resources/[maps]/playboy/license
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2025 BPTNetwork
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights to:
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+📌 Contributing Notice:
+By submitting a contribution (code, documentation, or other materials), you agree
+to license your contribution under the same MIT License and allow it to be freely
+used within the BPTNetwork project and its derivatives. Contributions must comply
+with the coding and quality standards defined by the maintainers.
+
+📌 Attribution Notice:
+All original work must retain proper attribution to BPTNetwork. If this resource is
+included in a larger package, credit must be clearly visible in documentation or
+README.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
A custom high-quality MLO map of the iconic Playboy Mansion for FiveM. Includes YMAP, YDR, YBN, YTYP, and other necessary map files. Optimized for seamless integration and immersive roleplay environments.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):