### PR TITLE
Improve Client Auto-Spawn Initialization on Map Start

### DIFF
--- a/server-data/resources/[gamemodes]/basic-gamemode/basic_client.lua
+++ b/server-data/resources/[gamemodes]/basic-gamemode/basic_client.lua
@@ -1,4 +1,15 @@
-AddEventHandler('onClientMapStart', function()
-  exports.spawnmanager:setAutoSpawn(true)
-  exports.spawnmanager:forceRespawn()
+AddEventHandler("onClientMapStart", function()
+    CreateThread(function()
+        -- Aspetta un attimo per sicurezza
+        Wait(500)
+
+        if exports.spawnmanager then
+            exports.spawnmanager:setAutoSpawn(true)
+            exports.spawnmanager:forceRespawn()
+
+            -- print("[DEBUG] AutoSpawn abilitato e respawn forzato eseguito.")
+        else
+            print("[ERRORE] spawnmanager non disponibile!")
+        end
+    end)
 end)

--- a/server-data/resources/[gamemodes]/basic-gamemode/fxmanifest.lua
+++ b/server-data/resources/[gamemodes]/basic-gamemode/fxmanifest.lua
@@ -1,14 +1,14 @@
 -- This resource is part of the default Cfx.re asset pack (cfx-server-data)
 -- Altering or recreating for local use only is strongly discouraged.
 
-version '1.0.0'
-author 'Cfx.re <root@cfx.re>'
-description 'A basic freeroam gametype that uses the default spawn logic from spawnmanager.'
-repository 'https://github.com/citizenfx/cfx-server-data'
+version("2.0.0")
+author("Cfx.re <root@cfx.re>")
+description("A basic freeroam gametype that uses the default spawn logic from spawnmanager.")
+repository("https://github.com/citizenfx/cfx-server-data")
 
-resource_type 'gametype' { name = 'Freeroam' }
+resource_type("gametype")({ name = "Freeroam" })
 
-client_script 'basic_client.lua'
+client_script("basic_client.lua")
 
-game 'common'
-fx_version 'adamant'
+game("common")
+fx_version("adamant")


### PR DESCRIPTION
## Summary

This pull request improves the initialization process for client auto-spawning when the map starts.

## Changes

- Wrapped logic inside `CreateThread` to avoid blocking the main thread.
- Added a small `Wait(500)` delay to prevent race conditions during early client loading.
- Added checks to ensure `spawnmanager` is available before calling its functions.
- Included optional debug logging for easier future troubleshooting.

## Why It Matters

These changes increase reliability and maintainability, especially in environments where the spawn manager may not be fully initialized immediately upon map load. It prevents potential errors and improves spawn consistency across client sessions.

## Notes

Feel free to uncomment the debug line if needed for further testing or diagnostics.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):