### PR TITLE
Potential fix for code scanning alert no. 663: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ESlint.yml
+++ b/.github/workflows/ESlint.yml
@@ -1,4 +1,6 @@
 name: ESLint
+permissions:
+  contents: read
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/bitpredator/empiretown/security/code-scanning/663](https://github.com/bitpredator/empiretown/security/code-scanning/663)

To fix this issue, add an explicit `permissions` block to the workflow file. The block should be placed either at the root of the workflow (top-level, recommended for single-job workflows like this one) or inside the individual job definition. The least-privilege setting for most linting-related workflows is `contents: read`, which only allows the workflow to fetch repository files as needed. Should the workflow require further permissions (such as commenting on pull requests), only those write permissions should be added. For the code shown, unless the ESLint action actually creates annotations or writes to pull requests, `contents: read` is sufficient. The change should be a single block added under the `name:` field, before the `on:` section, adhering to YAML structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
