### PR TITLE
💰 Data Heist Reward Update: black_money as item in ox_inventory

### DIFF
--- a/server-data/resources/[esx_addons]/cuchi_computer/server/main.lua
+++ b/server-data/resources/[esx_addons]/cuchi_computer/server/main.lua
@@ -27,7 +27,7 @@ if success then
         Framework.GetPlayers = Framework.Functions.GetPlayers
     end
 else
-    print("^1Error loading the framework.\n-> Check if you entered the good framework value and its resource name in ^7"..GetCurrentResourceName().."/config.lua\nNote that this resource ^1must^7 be started after your framework resource.")
+    print("^1Error loading the framework.\n-> Check if you entered the good framework value and its resource name in ^7" .. GetCurrentResourceName() .. "/config.lua\nNote that this resource ^1must^7 be started after your framework resource.")
 end
 
 math.randomseed(os.time())
@@ -118,7 +118,7 @@ if Config.DataHeists.Enabled then
                         end
                     end
 
-                    local netPath = "//".."breach-temp"..math.random(0, 100000).."/breached/data/dump-"..math.random(0, 100000)
+                    local netPath = "//" .. "breach-temp" .. math.random(0, 100000) .. "/breached/data/dump-" .. math.random(0, 100000)
                     breachPaths[netPath] = heistCoords
 
                     cb(netPath)
@@ -142,9 +142,12 @@ if Config.DataHeists.Enabled then
                     local reward = math.random(Config.DataHeists.Reward[1], Config.DataHeists.Reward[2])
 
                     if Config.Framework == "esx" then
-                        player.addMoney(reward)
+                        -- ESX con ox_inventory: aggiunta item black_money
+                        player.addInventoryItem("black_money", reward)
                     elseif Config.Framework == "qbcore" then
-                        player.Functions.AddMoney("cash", reward)
+                        -- QBCore con ox_inventory: aggiunta item black_money
+                        player.Functions.AddItem("black_money", reward)
+                        TriggerClientEvent("inventory:client:ItemBox", id, Framework.Shared.Items["black_money"], "add")
                     end
 
                     cb(true, reward)


### PR DESCRIPTION
# 💰 Data Heist Reward Update

### Major Changes
- Replaced the **clean money** reward with the **`black_money`` item for Data Heists.
- Direct integration with **ox_inventory**: Dirty money is now added as a **physical item** to the player's inventory.
- Support for both **ESX** and **QBCore**, with consistent handling of the `black_money` item.

### Developer Notes
- Ensure the `black_money` item is defined in `ox_inventory/data/items.lua` or in a custom file:
```lua
["black_money"] = {
label = "Dirty Money",
weight = 0,
stack = true,
close = true,
description = "Illegally obtained cash"
}
```
- With this change, black_money is no longer an account, but a physical object.

- Check for any third-party scripts that still use black_money as an account.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):