### PR TITLE
# Refactor NUI Escape Handler – Remove deprecated `event.which`

### DIFF
--- a/server-data/resources/[esx_addons]/esx_garage/client/main.lua
+++ b/server-data/resources/[esx_addons]/esx_garage/client/main.lua
@@ -99,7 +99,7 @@ CreateThread(function()
         EndTextCommandSetBlipName(blip)
     end
 
-    for k, v in pairs(Config.Impounds) do
+    for _, v in pairs(Config.Impounds) do
         local blip = AddBlipForCoord(v.GetOutPoint.x, v.GetOutPoint.y, v.GetOutPoint.z)
 
         SetBlipSprite(blip, v.Sprite)

--- a/server-data/resources/[esx_addons]/esx_garage/nui/js/app.js
+++ b/server-data/resources/[esx_addons]/esx_garage/nui/js/app.js
@@ -89,8 +89,8 @@ $(window).ready(function() {
 		$('li[data-page="impounded"]').removeClass('selected');
 	});
 
-	document.onkeyup = function(data) {
-		if (data.which == 27) {
+	document.addEventListener('keyup', function(event) {
+		if (event.key === 'Escape') {
 			$.post('https://esx_garage/escape', '{}');
 
 			$('.impounded_content').hide();
@@ -98,7 +98,7 @@ $(window).ready(function() {
 			$('li[data-page="garage"]').addClass('selected');
 			$('li[data-page="impounded"]').removeClass('selected');
 		}
-	};
+	});
 
 	function getVehicles(locale, vehicle, amount = null) {
 		let html = '';


### PR DESCRIPTION
### 🔧 Changes
- Replaced `document.onkeyup` with `document.addEventListener('keyup', ...)`.
- Replaced the use of the **deprecated** property `event.which` with the standard use of `event.key === "Escape"`.
- Optimized event handling to improve readability and compatibility with modern standards.

### ✅ Benefits
- Greater cross-browser compatibility and support for ECMAScript standards.
- Clearer and more maintainable code.
- Ability to add multiple listeners without risking accidental overwrites.
- Eliminated potential future warnings resulting from the use of deprecated APIs.

---

### 📝 Developer Notes
This change is part of a series of actions aimed at **modernizing the NUI code**, reducing dependencies on obsolete methods and improving the long-term stability of the user interface.

<!-- ⚠⚠ Do not delete this pull request template! ⚠⚠ -->
<!-- Pull requests that do not follow this template are likely to be ignored. -->

Fixes #[issue_no]
### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Does your submission pass tests?

**Please describe the changes this PR makes and why it should be merged:**


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):